### PR TITLE
Feat, BST, AVLTree 이터레이터 패턴 적용

### DIFF
--- a/Sources/AdvancedSwift/AVLTree/Iterator/InOrderLeftIterator.swift
+++ b/Sources/AdvancedSwift/AVLTree/Iterator/InOrderLeftIterator.swift
@@ -5,19 +5,28 @@
 //  Created by choijunios on 4/25/25.
 //
 
-public struct InOrderLeftIterator<Value: Comparable>: IteratorProtocol {
-    // State
+public enum TraversalType {
+    case inOrderLeft, inOrderRight
+}
+
+public struct TreeTraversalIterator<Value: Comparable>: IteratorProtocol {
     public typealias Element = Node<Value>
+    
+    // State
+    private let rootHolder: Element?
+    private let traversalType: TraversalType
     private var currentNode: Element?
     private var visited: Set<ObjectIdentifier> = .init()
     
-    init(startNode: Element?) {
+    init(traversalType: TraversalType, startNode: Element?) {
+        self.traversalType = traversalType
+        self.rootHolder = startNode
         self.currentNode = startNode
     }
     
     public mutating func next() -> Element? {
         guard let currentNode else { return nil }
-        let nextNode = inOrderLeftTraversal(current: currentNode)
+        let nextNode = getNext(currentNode)
         if let nextNode {
             self.currentNode = nextNode
             visit(nextNode)
@@ -35,15 +44,39 @@ public struct InOrderLeftIterator<Value: Comparable>: IteratorProtocol {
         return visited.contains(id)
     }
     
-    private func inOrderLeftTraversal(current: Element) -> Node<Value>? {
+    private func getNext(_ element: Element) -> Element? {
+        switch traversalType {
+        case .inOrderLeft:
+            inOrderLeftTraversal(current: element)
+        case .inOrderRight:
+            inOrderRightTraversal(current: element)
+        }
+    }
+}
+
+
+// MARK: Traversal method
+private extension TreeTraversalIterator {
+    func inOrderLeftTraversal(current: Element) -> Node<Value>? {
         if let leftChild = current.leftChild, !isVisited(leftChild) {
             return inOrderLeftTraversal(current: leftChild)
         }
-        
         if !isVisited(current) { return current }
-        
         if let rightChild = current.rightChild, !isVisited(rightChild) {
             return inOrderLeftTraversal(current: rightChild)
+        }
+        
+        if current.isRootNode { return nil }
+        return current.parent
+    }
+    
+    func inOrderRightTraversal(current: Element) -> Node<Value>? {
+        if let rightChild = current.rightChild, !isVisited(rightChild) {
+            return inOrderRightTraversal(current: rightChild)
+        }
+        if !isVisited(current) { return current }
+        if let leftChild = current.leftChild, !isVisited(leftChild) {
+            return inOrderRightTraversal(current: leftChild)
         }
         
         if current.isRootNode { return nil }

--- a/Sources/AdvancedSwift/AVLTree/Iterator/InOrderLeftIterator.swift
+++ b/Sources/AdvancedSwift/AVLTree/Iterator/InOrderLeftIterator.swift
@@ -1,0 +1,52 @@
+//
+//  InOrderLeftIterator.swift
+//  AdvancedSwift
+//
+//  Created by choijunios on 4/25/25.
+//
+
+public struct InOrderLeftIterator<Value: Comparable>: IteratorProtocol {
+    // State
+    public typealias Element = Node<Value>
+    private var currentNode: Element?
+    private var visited: Set<ObjectIdentifier> = .init()
+    
+    init(startNode: Element?) {
+        self.currentNode = startNode
+    }
+    
+    public mutating func next() -> Element? {
+        guard let currentNode else { return nil }
+        let nextNode = inOrderLeftTraversal(current: currentNode)
+        if let nextNode {
+            self.currentNode = nextNode
+            visit(nextNode)
+        }
+        return nextNode
+    }
+    
+    private mutating func visit(_ node: Element) {
+        let id = ObjectIdentifier(node)
+        visited.insert(id)
+    }
+    
+    private func isVisited(_ node: Element) -> Bool {
+        let id = ObjectIdentifier(node)
+        return visited.contains(id)
+    }
+    
+    private func inOrderLeftTraversal(current: Element) -> Node<Value>? {
+        if let leftChild = current.leftChild, !isVisited(leftChild) {
+            return inOrderLeftTraversal(current: leftChild)
+        }
+        
+        if !isVisited(current) { return current }
+        
+        if let rightChild = current.rightChild, !isVisited(rightChild) {
+            return inOrderLeftTraversal(current: rightChild)
+        }
+        
+        if current.isRootNode { return nil }
+        return current.parent
+    }
+}

--- a/Sources/AdvancedSwift/AVLTree/Iterator/TreeTraversalIterator.swift
+++ b/Sources/AdvancedSwift/AVLTree/Iterator/TreeTraversalIterator.swift
@@ -1,5 +1,5 @@
 //
-//  InOrderLeftIterator.swift
+//  TreeTraversalIterator.swift
 //  AdvancedSwift
 //
 //  Created by choijunios on 4/25/25.
@@ -13,15 +13,15 @@ public struct TreeTraversalIterator<Value: Comparable>: IteratorProtocol {
     public typealias Element = Node<Value>
     
     // State
-    private let rootHolder: Element?
+    private let entry: Element?
     private let traversalType: TraversalType
     private var currentNode: Element?
     private var visited: Set<ObjectIdentifier> = .init()
     
-    init(traversalType: TraversalType, startNode: Element?) {
+    init(traversalType: TraversalType, entryNode: EntryNode<Value>?) {
         self.traversalType = traversalType
-        self.rootHolder = startNode
-        self.currentNode = startNode
+        self.entry = entryNode
+        self.currentNode = entryNode?.child
     }
     
     public mutating func next() -> Element? {
@@ -67,7 +67,7 @@ private extension TreeTraversalIterator {
         }
         
         if current.isRootNode { return nil }
-        return current.parent
+        return inOrderLeftTraversal(current: current.parent!)
     }
     
     func inOrderRightTraversal(current: Element) -> Node<Value>? {
@@ -80,6 +80,6 @@ private extension TreeTraversalIterator {
         }
         
         if current.isRootNode { return nil }
-        return current.parent
+        return inOrderRightTraversal(current: current.parent!)
     }
 }

--- a/Sources/AdvancedSwift/AVLTree/README.md
+++ b/Sources/AdvancedSwift/AVLTree/README.md
@@ -16,13 +16,38 @@ let tree = AVLTree<Int>()
 ### Read
 
 아래 함수들을 사용하여 가장 트리내부 값들을 추출할 수 있습니다.
+
+매개변수로 nil값을 전달하는 경우 정렬된 전체 리스트를 반환합니다.
 ```swift
 // 가장 작은 수부터 오름차순 추출
-func getAscendingList(maxCount: Int) -> [Value]
+func getAscendingList(maxCount: Int? = nil) -> [Value]
 
 // 가장 큰 수부터 내림차순 추출
-func getDiscendingList(maxCount: Int) -> [Value]
+func getDiscendingList(maxCount: Int? = nil) -> [Value]
 ```
+
+해당 자료구조는 `Sequence`프로토콜을 준수하기 때문에 `for-in`문을 사용할 수 있습니다.
+
+매 순회마다 새로운 이터레이터를 반환하기 때문에 순회의 독립성이 지켜집니다.
+
+기본적으로 반환되는 이터레이터는 오름차순 이터레이터 이지만 `setter`함수를 사용해 기본적으로 사용되는 순회방식을 결정할 수 있습니다.
+
+```swift
+for element in tree {
+    // default, ASC
+}
+
+for element in tree.setIterationType(.inOrderLeft) {
+    ...
+}
+
+for element in tree.setIterationType(.inOrderRight) {
+    // 내림차순 리스트를 순회하는 효과를 사용할 수 있습니다.
+    // 이후 순회부터는 내림 차순이 기본값으로 쓰이기에 주의가 필요합니다.
+}
+
+```
+
 
 ### Delete
 

--- a/Sources/AdvancedSwift/AVLTree/Tree/AVLTree.swift
+++ b/Sources/AdvancedSwift/AVLTree/Tree/AVLTree.swift
@@ -6,7 +6,6 @@
 //
 
 final public class AVLTree<Value: Comparable>: BinarySearchTree<Value> {
-
     override func createNode(value: Value, parent: Node<Value>) -> Node<Value> {
         AVLNode(value: value, parent: parent)
     }
@@ -41,12 +40,6 @@ final public class AVLTree<Value: Comparable>: BinarySearchTree<Value> {
         } catch {
             print("[\(Self.self)] \(error)")
         }
-    }
-    
-    public func copy() -> AVLTree {
-        let d_self = AVLTree<Value>()
-        d_self.setEntry(entryNode.copy())
-        return d_self as! Self
     }
 }
 

--- a/Sources/AdvancedSwift/AVLTree/Tree/BinarySearchTree.swift
+++ b/Sources/AdvancedSwift/AVLTree/Tree/BinarySearchTree.swift
@@ -168,7 +168,7 @@ public extension BinarySearchTree {
         return list
     }
     
-    final func getDiscendingList(maxCount: UInt? = nil) -> [Value] {
+    final func getDescendingList(maxCount: UInt? = nil) -> [Value] {
         var list: [Value] = []
         var iterator = TreeTraversalIterator(traversalType: .inOrderRight, entryNode: entryNode)
         while let nextElement = iterator.next() {

--- a/Sources/AdvancedSwift/AVLTree/Tree/BinarySearchTree.swift
+++ b/Sources/AdvancedSwift/AVLTree/Tree/BinarySearchTree.swift
@@ -158,22 +158,22 @@ public extension BinarySearchTree {
 
 // MARK: Public interface: sorted list
 public extension BinarySearchTree {
-    final func getAscendingList(maxCount: UInt) -> [Value] {
-        guard let rootNode else { return [] }
+    final func getAscendingList(maxCount: UInt? = nil) -> [Value] {
         var list: [Value] = []
-        var iterator = TreeTraversalIterator(traversalType: .inOrderLeft, startNode: rootNode)
+        var iterator = TreeTraversalIterator(traversalType: .inOrderLeft, entryNode: entryNode)
         while let nextElement = iterator.next() {
             list.append(nextElement.value)
+            if let maxCount, list.count >= maxCount { break }
         }
         return list
     }
     
-    final func getDiscendingList(maxCount: UInt) -> [Value] {
-        guard let rootNode else { return [] }
+    final func getDiscendingList(maxCount: UInt? = nil) -> [Value] {
         var list: [Value] = []
-        var iterator = TreeTraversalIterator(traversalType: .inOrderRight, startNode: rootNode)
+        var iterator = TreeTraversalIterator(traversalType: .inOrderRight, entryNode: entryNode)
         while let nextElement = iterator.next() {
             list.append(nextElement.value)
+            if let maxCount, list.count >= maxCount { break }
         }
         return list
     }
@@ -190,7 +190,7 @@ public extension BinarySearchTree {
  
     func makeIterator() -> TreeTraversalIterator<Value> {
         let copied = self.copy()
-        return TreeTraversalIterator(traversalType: traversalType, startNode: copied.rootNode)
+        return TreeTraversalIterator(traversalType: traversalType, entryNode: copied.entryNode)
     }
 }
 

--- a/Sources/AdvancedSwift/AVLTree/Tree/BinarySearchTree.swift
+++ b/Sources/AdvancedSwift/AVLTree/Tree/BinarySearchTree.swift
@@ -11,7 +11,10 @@ open class BinarySearchTree<Value: Comparable>: Sequence {
     
     var rootNode: Node<Value>? { entryNode.child }
     
-    public init() { }
+    // Interation
+    private(set) var traversalType: TraversalType = .inOrderLeft
+    
+    public required init() { }
     
     public var isEmpty: Bool { rootNode == nil }
     func setEntry(_ node: EntryNode<Value>) { self.entryNode = node }
@@ -25,6 +28,13 @@ open class BinarySearchTree<Value: Comparable>: Sequence {
     }
     func onRemoval(removalInfo: BSTNodeRemoval) { }
     func onInsertion(insertedNode: Node<Value>) { }
+    
+    public func copy() -> Self {
+        let d_self = Self.init()
+        d_self.traversalType = self.traversalType
+        d_self.setEntry(entryNode.copy())
+        return d_self
+    }
 }
 
 
@@ -151,14 +161,20 @@ public extension BinarySearchTree {
     final func getAscendingList(maxCount: UInt) -> [Value] {
         guard let rootNode else { return [] }
         var list: [Value] = []
-        inOrderLeftTraversal(node: rootNode, list: &list, maxCount: maxCount)
+        var iterator = TreeTraversalIterator(traversalType: .inOrderLeft, startNode: rootNode)
+        while let nextElement = iterator.next() {
+            list.append(nextElement.value)
+        }
         return list
     }
     
     final func getDiscendingList(maxCount: UInt) -> [Value] {
         guard let rootNode else { return [] }
         var list: [Value] = []
-        inOrderRightTraversal(node: rootNode, list: &list, maxCount: maxCount)
+        var iterator = TreeTraversalIterator(traversalType: .inOrderRight, startNode: rootNode)
+        while let nextElement = iterator.next() {
+            list.append(nextElement.value)
+        }
         return list
     }
 }
@@ -166,38 +182,21 @@ public extension BinarySearchTree {
 
 // MARK: Iterator
 public extension BinarySearchTree {
-    func getInOrderLeftIterator() -> InOrderLeftIterator<Value> { InOrderLeftIterator(startNode: rootNode) }
-    func makeIterator() -> InOrderLeftIterator<Value> { getInOrderLeftIterator() }
+    @discardableResult
+    func setIterationType(_ traversalType: TraversalType) -> Self {
+        self.traversalType = traversalType
+        return self
+    }
+ 
+    func makeIterator() -> TreeTraversalIterator<Value> {
+        let copied = self.copy()
+        return TreeTraversalIterator(traversalType: traversalType, startNode: copied.rootNode)
+    }
 }
 
-// MARK: 순회 함수
+
+// MARK: 내부 순회 함수
 private extension BinarySearchTree {
-    func inOrderLeftTraversal(node: Node<Value>, list: inout [Value], maxCount: UInt) {
-        if let leftChild = node.leftChild {
-            inOrderLeftTraversal(node: leftChild, list: &list, maxCount: maxCount)
-        }
-        
-        if list.count >= maxCount { return }
-        list.append(node.value)
-        
-        if let rightChild = node.rightChild {
-            inOrderLeftTraversal(node: rightChild, list: &list, maxCount: maxCount)
-        }
-    }
-    
-    func inOrderRightTraversal(node: Node<Value>, list: inout [Value], maxCount: UInt) {
-        if let rightChild = node.rightChild {
-            inOrderRightTraversal(node: rightChild, list: &list, maxCount: maxCount)
-        }
-        
-        if list.count >= maxCount { return }
-        list.append(node.value)
-        
-        if let leftChild = node.leftChild {
-            inOrderRightTraversal(node: leftChild, list: &list, maxCount: maxCount)
-        }
-    }
-    
     func postOrderTraversal(node: Node<Value>, action: (Node<Value>) -> ()) {
         if let leftChild = node.leftChild {
             postOrderTraversal(node: leftChild, action: action)

--- a/Sources/AdvancedSwift/AVLTree/Tree/BinarySearchTree.swift
+++ b/Sources/AdvancedSwift/AVLTree/Tree/BinarySearchTree.swift
@@ -5,7 +5,7 @@
 //  Created by choijunios on 4/10/25.
 //
 
-open class BinarySearchTree<Value: Comparable> {
+open class BinarySearchTree<Value: Comparable>: Sequence {
     // State
     private(set) var entryNode: EntryNode<Value> = .init(value: nil)
     
@@ -163,6 +163,12 @@ public extension BinarySearchTree {
     }
 }
 
+
+// MARK: Iterator
+public extension BinarySearchTree {
+    func getInOrderLeftIterator() -> InOrderLeftIterator<Value> { InOrderLeftIterator(startNode: rootNode) }
+    func makeIterator() -> InOrderLeftIterator<Value> { getInOrderLeftIterator() }
+}
 
 // MARK: 순회 함수
 private extension BinarySearchTree {

--- a/Sources/AdvancedSwift/HashMap/HashMap.swift
+++ b/Sources/AdvancedSwift/HashMap/HashMap.swift
@@ -50,7 +50,7 @@ public extension HashMap {
         case .ASC:
             return keyTree.getAscendingList(maxCount: bound)
         case .DESC:
-            return keyTree.getDiscendingList(maxCount: bound)
+            return keyTree.getDescendingList(maxCount: bound)
         }
     }
     

--- a/Tests/AdvancedSwiftTests/AVLTreeTests.swift
+++ b/Tests/AdvancedSwiftTests/AVLTreeTests.swift
@@ -29,6 +29,7 @@ struct AVLTreeRandomListTests {
                 tree.insert(number)
             }
             
+            
             // When, 랜덤 삭제
             var erased: [Int] = []
             for _ in (0..<3) {
@@ -40,6 +41,7 @@ struct AVLTreeRandomListTests {
                     throw AVLTreeError.nodeIsNotReleased
                 }
             }
+            
             
             // Then, 삭제한 리스트와 삭제된 리스트를 합쳤을 때 원본과 같아야 한다.
             list.append(contentsOf: erased)
@@ -62,11 +64,13 @@ struct AVLTreeMemoryLeakTests {
         var list = orginal_list
         list.forEach(tree.insert(_:))
         
+        
         // When
         for _ in 0..<100 {
             guard let element = list.randomElement() else { continue }
             list.removeAll(where: { $0 == element })
             let leakChecker = tree.remove(element)
+            
             
             // Then
             #expect(leakChecker != nil)
@@ -81,8 +85,10 @@ struct AVLTreeMemoryLeakTests {
         let list = Array(Set((0..<10000).map({ _ in Int.random(in: 1..<100000) })))
         list.forEach(tree.insert)
         
+        
         // When
         let checkers = tree.clearWithCheckers()
+        
         
         // Then
         #expect(checkers.count == list.count)
@@ -99,10 +105,12 @@ struct AVLTreeInsertRemoveExceptionTests {
         // Given
         let tree = AVLTree<Int>()
         
+        
         // When
         tree.insert(1)
         tree.insert(1)
         tree.insert(1)
+        
         
         // Then, 중복요소는 무시한다.
         #expect(tree.treeHeight == 1)
@@ -114,8 +122,10 @@ struct AVLTreeInsertRemoveExceptionTests {
         let tree = AVLTree<Int>()
         tree.insert(1)
         
+        
         // When
         let leakChecker = tree.remove(2)
+        
         
         // Then, 요소가 없음으로 해당 요소 대한 매모리 누수 감지기가 반환되지 않는다.
         #expect(leakChecker == nil)
@@ -131,10 +141,12 @@ struct AVLTreeRotationTests {
         // Given
         let tree = AVLTree<Int>()
         
+        
         // When, LL상태
         tree.insert(3)
         tree.insert(2)
         tree.insert(1)
+        
         
         // Then
         // - 회전으로 인해 균형이 맞춰짐
@@ -146,10 +158,12 @@ struct AVLTreeRotationTests {
         // Given
         let tree = AVLTree<Int>()
         
+        
         // When, RR상태
         tree.insert(1)
         tree.insert(2)
         tree.insert(3)
+        
         
         // Then
         // - 회전으로 인해 균형이 맞춰짐
@@ -161,10 +175,12 @@ struct AVLTreeRotationTests {
         // Given
         let tree = AVLTree<Int>()
         
+        
         // When, LR상태
         tree.insert(3)
         tree.insert(1)
         tree.insert(2)
+        
         
         // Then
         // - 회전으로 인해 균형이 맞춰짐
@@ -176,10 +192,12 @@ struct AVLTreeRotationTests {
         // Given
         let tree = AVLTree<Int>()
         
+        
         // When, RL상태
         tree.insert(1)
         tree.insert(3)
         tree.insert(2)
+        
         
         // Then
         // - 회전으로 인해 균형이 맞춰짐
@@ -188,7 +206,7 @@ struct AVLTreeRotationTests {
 }
 
 
-struct DuplicationTest {
+struct AVLTreeDuplicationTest {
     @Test
     func checkDeleteRespectively() {
         // Given
@@ -198,6 +216,7 @@ struct DuplicationTest {
             origin_tree.insert($0)
         }
         
+        
         // When
         let d_tree = origin_tree.copy()
         origin_tree.clear()
@@ -206,7 +225,7 @@ struct DuplicationTest {
         // Then
         #expect(origin_tree.isEmpty)
         let ascedingList = insertingList.sorted(by: { $0 < $1 })
-        #expect(d_tree.getAscendingList(maxCount: 3) == ascedingList)
+        #expect(d_tree.getAscendingList() == ascedingList)
     }
     
     @Test
@@ -215,13 +234,38 @@ struct DuplicationTest {
         let origin_tree = AVLTree<Int>()
         let d_tree = origin_tree.copy()
         
+        
         // When
         let insertingList = [1,2,3]
         insertingList.forEach {
             origin_tree.insert($0)
         }
         
+        
         // Then
         #expect(d_tree.isEmpty)
+    }
+}
+
+
+struct AVLTreeSliceTest {
+    @Test("설정한 개수만큼의 리스트를 확보하는지 확인한다.")
+    func checkListSizeLimit() {
+        // Given
+        let insertingList = Array(0..<1000)
+        let tree = AVLTree<Int>()
+        insertingList.forEach {
+            tree.insert($0)
+        }
+        
+        
+        // When
+        let ascendingList = tree.getAscendingList(maxCount: 10)
+        let descendingList = tree.getDiscendingList(maxCount: 10)
+        
+        
+        // Then
+        #expect(Array(insertingList.sorted(by: <)[0..<10]) == ascendingList)
+        #expect(Array(insertingList.sorted(by: >)[0..<10]) == descendingList)
     }
 }

--- a/Tests/AdvancedSwiftTests/AVLTreeTests.swift
+++ b/Tests/AdvancedSwiftTests/AVLTreeTests.swift
@@ -261,7 +261,7 @@ struct AVLTreeSliceTest {
         
         // When
         let ascendingList = tree.getAscendingList(maxCount: 10)
-        let descendingList = tree.getDiscendingList(maxCount: 10)
+        let descendingList = tree.getDescendingList(maxCount: 10)
         
         
         // Then

--- a/Tests/AdvancedSwiftTests/BSTTests.swift
+++ b/Tests/AdvancedSwiftTests/BSTTests.swift
@@ -1,0 +1,34 @@
+//
+//  BSTTests.swift
+//  AdvancedSwift
+//
+//  Created by choijunios on 4/25/25.
+//
+
+import Testing
+
+@testable import AdvancedSwift
+
+struct BSTIteratorTests {
+    
+    @Test("좌측 중위 순회 이터레이터 순회 테스트")
+    func checkInOrderLeftIterator() {
+        // Given
+        let tree = BinarySearchTree<Int>()
+        
+        // When
+        // - 역순으로 삽입
+        let insertingList = (0..<1000).reversed()
+        for index in insertingList {
+            tree.insert(index)
+        }
+        
+        // Then
+        var list: [Int] = []
+        for element in tree {
+            list.append(element.value)
+        }
+        #expect(list == insertingList.reversed())
+    }
+    
+}

--- a/Tests/AdvancedSwiftTests/BSTTests.swift
+++ b/Tests/AdvancedSwiftTests/BSTTests.swift
@@ -16,6 +16,7 @@ struct BSTIteratorTests {
         // Given
         let tree = BinarySearchTree<Int>()
         
+        
         // When
         // - 역순으로 삽입
         let insertingList = (0..<1000).reversed()
@@ -23,12 +24,33 @@ struct BSTIteratorTests {
             tree.insert(index)
         }
         
+        
         // Then
         var list: [Int] = []
-        for element in tree {
+        for element in tree.setIterationType(.inOrderLeft) {
             list.append(element.value)
         }
         #expect(list == insertingList.reversed())
     }
     
+    @Test("우측 중위 순회 이터레이터 순회 테스트")
+    func checkInOrderRightIterator() {
+        // Given
+        let tree = BinarySearchTree<Int>()
+        
+        
+        // When
+        let insertingList = (0..<1000)
+        for index in insertingList {
+            tree.insert(index)
+        }
+        
+        
+        // Then
+        var list: [Int] = []
+        for element in tree.setIterationType(.inOrderRight) {
+            list.append(element.value)
+        }
+        #expect(list == insertingList.reversed())
+    }
 }

--- a/Tests/AdvancedSwiftTests/HashMapTests.swift
+++ b/Tests/AdvancedSwiftTests/HashMapTests.swift
@@ -22,6 +22,8 @@ struct HashMapKeySyncTest {
         
         // Then
         #expect(map.keys.count == map.keys(order: .ASC).count)
+        #expect(map.keys.count == map.keys(order: .DESC).count)
+        #expect(map.keys.sorted(by: <) == map.keys(order: .ASC))
         #expect(map.keys.sorted(by: >) == map.keys(order: .DESC))
     }
 }


### PR DESCRIPTION
## 변경된 점

- BST, AVLTree 이터레이터 패턴 적용

### BST, AVLTree 이터레이터 패턴 적용

BST가 `Sequence`프로토콜을 따르도록하여 `for-in`문을 사용할 수 있도록 했습니다.
자세한 사용 부분은 리드미 확인 바랍니다.